### PR TITLE
Pre v1 feedback

### DIFF
--- a/R/11_printCriticalCheck1.R
+++ b/R/11_printCriticalCheck1.R
@@ -45,10 +45,13 @@ printCriticalCheck <- function(.criticalCheckId, .criticalCheckResults){
     "criticalCheck5" = {
       cat(paste0("Number Added Rows: ", .criticalCheckResults$nAddedRows, "  \n"))
       cat(paste0("Number of Old Rows: ", .criticalCheckResults$nOldRows, "  \n"))
-      cat(paste0("Proportion of Row Increase: ", .criticalCheckResults$propRowIncrease, "  \n"))
+      cat(paste0("Percent of Row Increase: ", .criticalCheckResults$pctRowIncrease, "  \n"))
+      cat(paste0("Comparison Threshold: ", 100 * .criticalCheckResults$threshold, "  \n"))
       cat(paste0("  \n"))
     },
     "criticalCheck6" = {
+      cat(paste0("Number of Removed Rows: ", .criticalCheckResults$nRemovedRows, "  \n"))
+      cat(paste0("Comparison Threshold: ", .criticalCheckResults$threshold, "  \n"))
       if(nrow(.criticalCheckResults$inOldAndNotInNew) > 0){
         print(knitr::kable(.criticalCheckResults$inOldAndNotInNew))
       }

--- a/R/11_printCriticalCheck1.R
+++ b/R/11_printCriticalCheck1.R
@@ -69,7 +69,7 @@ printCriticalCheck <- function(.criticalCheckId, .criticalCheckResults){
       if(!is.null(.criticalCheckResults)){
         if(nrow(.criticalCheckResults$essentialVariablesMissingness) > 0){
           .dsToPrint <- .criticalCheckResults$essentialVariablesMissingness |>
-            dplyr::select(varName, nRows, nMissing, pctMissing, pctMissingComp, acceptableMissingness, skipLogic)
+            dplyr::select(varName, nRowsThisMonth, nMissingThisMonth, pctMissingThisMonth, pctMissingLastMonth, acceptableMissingness, skipLogic)
           print(knitr::kable(.dsToPrint))
         }
       }

--- a/R/11_printCriticalCheck1.R
+++ b/R/11_printCriticalCheck1.R
@@ -7,7 +7,8 @@
 #' @importFrom rmarkdown paged_table
 printCriticalCheck <- function(.criticalCheckId, .criticalCheckResults){
   # Create header and print critical checks to report
-  cat(paste0("### ", .criticalCheckId, " - ", .criticalCheckResults$checkTitle , "  \n"))
+  # cat(paste0("### ", .criticalCheckId, " - ", .criticalCheckResults$checkTitle , "  \n"))
+  cat(paste0("### Results of Critical Check ", as.numeric(gsub("\\D", "", .criticalCheckId)), " - ", .criticalCheckResults$checkTitle , "  \n"))
   cat(paste0("Description: ", .criticalCheckResults$checkDescription, "  \n"))
   cat(paste0("Pass: ", .criticalCheckResults$pass, "  \n"))
   cat(paste0("  \n"))
@@ -65,7 +66,7 @@ printCriticalCheck <- function(.criticalCheckId, .criticalCheckResults){
       if(!is.null(.criticalCheckResults)){
         if(nrow(.criticalCheckResults$essentialVariablesMissingness) > 0){
           .dsToPrint <- .criticalCheckResults$essentialVariablesMissingness |>
-            dplyr::select(varName, nRows, nMissing, propMissing, propMissingComp, acceptableMissingness, skipLogic)
+            dplyr::select(varName, nRows, nMissing, pctMissing, pctMissingComp, acceptableMissingness, skipLogic)
           print(knitr::kable(.dsToPrint))
         }
       }

--- a/R/11_printCriticalCheck1.R
+++ b/R/11_printCriticalCheck1.R
@@ -74,6 +74,16 @@ printCriticalCheck <- function(.criticalCheckId, .criticalCheckResults){
         }
       }
       cat(paste0("  \n"))
+    },
+    "criticalCheck9" = {
+      if(!is.null(.criticalCheckResults)){
+        cat(paste0("Number Failed: ", .criticalCheckResults$nVariablesUnexpectedType, "  \n"))
+        if(nrow(.criticalCheckResults$listOfVarsWithUnexpectedType) > 0){
+          .dsToPrint <- .criticalCheckResults$listOfVarsWithUnexpectedType
+          print(knitr::kable(.dsToPrint))
+        }
+      }
+      cat(paste0("  \n"))
     }
   )
 }

--- a/R/11_printCriticalCheck1.R
+++ b/R/11_printCriticalCheck1.R
@@ -69,7 +69,7 @@ printCriticalCheck <- function(.criticalCheckId, .criticalCheckResults){
       if(!is.null(.criticalCheckResults)){
         if(nrow(.criticalCheckResults$essentialVariablesMissingness) > 0){
           .dsToPrint <- .criticalCheckResults$essentialVariablesMissingness |>
-            dplyr::select(varName, nRowsThisMonth, nMissingThisMonth, pctMissingThisMonth, pctMissingLastMonth, acceptableMissingness, skipLogic)
+            dplyr::select(varName, nMissingThisMonth, nRowsThisMonth, pctMissingThisMonth, pctMissingLastMonth, acceptableMissingness, skipLogic)
           print(knitr::kable(.dsToPrint))
         }
       }

--- a/R/scratch.R
+++ b/R/scratch.R
@@ -1,5 +1,5 @@
 # generateReport(
-#   .inputDatasetUrl = "C:/Users/ScottKreider/Documents/scrap/store/2024_04_25_11_38_08/checks/2024-02-01_2024_04_25_11_38_08_checks.rds"
+#   .inputDatasetUrl = "C:/Users/ScottKreider/Documents/scrap/store/2024_04_25_14_15_41/checks/2024-02-01_2024_04_25_14_15_41_checks.rds"
 #   ,.reportOutputUrl = "C:/Users/ScottKreider/Documents/scrap/report/"
 #   ,.fileName = "outputReport"
 # )

--- a/R/scratch.R
+++ b/R/scratch.R
@@ -1,5 +1,5 @@
 # generateReport(
-#   .inputDatasetUrl = "C:/Users/ScottKreider/OneD - Corrona LLC/Corrona LLC/Biostat Data Files - DQ Reports/ad/2024/2024-03-06/2024_03_22_11_49_48/checks/2024-03-06_2024_03_22_11_49_48_checks.rds"
+#   .inputDatasetUrl = "C:/Users/ScottKreider/Documents/scrap/store/2024_04_25_11_38_08/checks/2024-02-01_2024_04_25_11_38_08_checks.rds"
 #   ,.reportOutputUrl = "C:/Users/ScottKreider/Documents/scrap/report/"
 #   ,.fileName = "outputReport"
 # )

--- a/R/scratch.R
+++ b/R/scratch.R
@@ -1,5 +1,5 @@
 # generateReport(
-#   .inputDatasetUrl = "C:/Users/ScottKreider/Documents/scrap/store/2024_04_25_14_15_41/checks/2024-02-01_2024_04_25_14_15_41_checks.rds"
+#   .inputDatasetUrl = "C:/Users/ScottKreider/Documents/scrap/store/2024_04_26_11_26_07/checks/2024-04-02_2024_04_26_11_26_07_checks.rds"
 #   ,.reportOutputUrl = "C:/Users/ScottKreider/Documents/scrap/report/"
 #   ,.fileName = "outputReport"
 # )

--- a/R/scratch.R
+++ b/R/scratch.R
@@ -1,5 +1,5 @@
 # generateReport(
-#   .inputDatasetUrl = "C:/Users/ScottKreider/Documents/scrap/store/2024_04_26_11_26_07/checks/2024-04-02_2024_04_26_11_26_07_checks.rds"
+#   .inputDatasetUrl = "C:/Users/ScottKreider/Documents/scrap/store/2024-04-29_1341/checks/ad_2024-04-02_2024-04-29_1341_checks.rds"
 #   ,.reportOutputUrl = "C:/Users/ScottKreider/Documents/scrap/report/"
 #   ,.fileName = "outputReport"
 # )

--- a/inst/rmarkdown/template.Rmd
+++ b/inst/rmarkdown/template.Rmd
@@ -85,10 +85,10 @@ cat(paste0("# ", datasetName, "  \n\n"))
         
         if(.noncriticalCheckId == "nc3") {
           .dsToPrint <- params$checkDataset$nonCriticalChecks[[datasetName]]$codebookChecks[[.noncriticalCheckId]]$listing |>
-            dplyr::select(varName, nRows, nMissing, pctMissing, acceptableMissingness, skipLogic)
+            dplyr::select(varName, nMissing, nRows, pctMissing, acceptableMissingness, skipLogic)
         } else if (.noncriticalCheckId == "nc4") {
           .dsToPrint <- params$checkDataset$nonCriticalChecks[[datasetName]]$codebookChecks[[.noncriticalCheckId]]$listing |>
-            dplyr::select(varName, nRows, nMissing, pctMissing, pctMissingComp, acceptableMissingness, skipLogic)
+            dplyr::select(varName, nMissing, nRows, pctMissing, pctMissingComp, acceptableMissingness, skipLogic)
         } else {
           .dsToPrint <- params$checkDataset$nonCriticalChecks[[datasetName]]$codebookChecks[[.noncriticalCheckId]]$listing
         }

--- a/inst/rmarkdown/template.Rmd
+++ b/inst/rmarkdown/template.Rmd
@@ -95,10 +95,10 @@ cat(paste0("# ", datasetName, "  \n\n"))
         
         if(.noncriticalCheckId == "nc3") {
           .dsToPrint <- params$checkDataset$nonCriticalChecks[[datasetName]]$codebookChecks[[.noncriticalCheckId]]$listing |>
-            dplyr::select(varName, nMissing, nRows, pctMissing, acceptableMissingness, skipLogic)
+            dplyr::select(varName, nMissingThisMonth, nRowsThisMonth, pctMissingThisMonth, acceptableMissingness, skipLogic)
         } else if (.noncriticalCheckId == "nc4") {
           .dsToPrint <- params$checkDataset$nonCriticalChecks[[datasetName]]$codebookChecks[[.noncriticalCheckId]]$listing |>
-            dplyr::select(varName, nMissing, nRows, pctMissing, pctMissingComp, acceptableMissingness, skipLogic)
+            dplyr::select(varName, nMissingThisMonth, nRowsThisMonth, pctMissingThisMonth, pctMissingLastMonth, acceptableMissingness, skipLogic)
         } else {
           .dsToPrint <- params$checkDataset$nonCriticalChecks[[datasetName]]$codebookChecks[[.noncriticalCheckId]]$listing
         }

--- a/inst/rmarkdown/template.Rmd
+++ b/inst/rmarkdown/template.Rmd
@@ -27,6 +27,16 @@ cat(paste0("**Data pull date:** ",params$checkDataset$runnerSummary$pullDate,"  
 
 ## Critical Check Summary
 
+cc1: Zero duplicates
+cc2: Added variables
+cc3: Removed variables
+cc4: Zero unlabeled variables
+cc5: Reasonable volume of new rows
+cc6: Reasonable volume of disappearing rows
+cc7: Item nonresponse for essential variables is not extreme
+cc8: MoM (month over month) change in item nonresponse is reasonable for essential variables
+cc9: Variables are of unexpected ‘type’
+
 ```{r echo = FALSE, results = "asis"}
 summaryToPrint <- params$checkDataset$checkSummary$criticalCheckSummary
 DT::datatable(summaryToPrint) |>

--- a/inst/rmarkdown/template.Rmd
+++ b/inst/rmarkdown/template.Rmd
@@ -27,19 +27,19 @@ cat(paste0("**Data pull date:** ",params$checkDataset$runnerSummary$pullDate,"  
 
 ## Critical Check Summary
 
-cc1: Zero duplicates
-cc2: Added variables
-cc3: Removed variables
-cc4: Zero unlabeled variables
-cc5: Reasonable volume of new rows
-cc6: Reasonable volume of disappearing rows
-cc7: Item nonresponse for essential variables is not extreme
-cc8: MoM (month over month) change in item nonresponse is reasonable for essential variables
-cc9: Variables are of unexpected ‘type’
+* cc1: Zero duplicates
+* cc2: Added variables
+* cc3: Removed variables
+* cc4: Zero unlabeled variables
+* cc5: Reasonable volume of new rows
+* cc6: Reasonable volume of disappearing rows
+* cc7: Item nonresponse for essential variables is not extreme
+* cc8: MoM (month over month) change in item nonresponse is reasonable for essential variables
+* cc9: Variables are of unexpected ‘type’
 
 ```{r echo = FALSE, results = "asis"}
 summaryToPrint <- params$checkDataset$checkSummary$criticalCheckSummary
-DT::datatable(summaryToPrint) |>
+DT::datatable(summaryToPrint, options = list(dom = 't')) |>
   DT::formatStyle(
     names(summaryToPrint)
     ,backgroundColor = DT::styleEqual(c("Fail", "Pass"), c("#FF7F7F", "#D1FFBD"))
@@ -51,7 +51,7 @@ cat(paste0("  \n\n"))
 ## Noncritical Check Summary
 
 ```{r echo = FALSE, results = "asis"}
-DT::datatable(params$checkDataset$checkSummary$nonCriticalCheckSummary)
+DT::datatable(params$checkDataset$checkSummary$nonCriticalCheckSummary, options = list(dom = 't'))
 
 cat(paste0("  \n\n"))
 

--- a/inst/rmarkdown/template.Rmd
+++ b/inst/rmarkdown/template.Rmd
@@ -85,16 +85,16 @@ cat(paste0("# ", datasetName, "  \n\n"))
         
         if(.noncriticalCheckId == "nc3") {
           .dsToPrint <- params$checkDataset$nonCriticalChecks[[datasetName]]$codebookChecks[[.noncriticalCheckId]]$listing |>
-            dplyr::select(varName, nRows, nMissing, propMissing, acceptableMissingness, skipLogic)
+            dplyr::select(varName, nRows, nMissing, pctMissing, acceptableMissingness, skipLogic)
         } else if (.noncriticalCheckId == "nc4") {
           .dsToPrint <- params$checkDataset$nonCriticalChecks[[datasetName]]$codebookChecks[[.noncriticalCheckId]]$listing |>
-            dplyr::select(varName, nRows, nMissing, propMissing, propMissingComp, acceptableMissingness, skipLogic)
+            dplyr::select(varName, nRows, nMissing, pctMissing, pctMissingComp, acceptableMissingness, skipLogic)
         } else {
           .dsToPrint <- params$checkDataset$nonCriticalChecks[[datasetName]]$codebookChecks[[.noncriticalCheckId]]$listing
         }
     
-        cat(paste0("###  "
-                   ,.noncriticalCheckId
+        cat(paste0("###  Results of Non-Critical Check "
+                   ,as.numeric(gsub("\\D", "", .noncriticalCheckId))
                    ," - ", params$checkDataset$nonCriticalChecks[[datasetName]]$codebookChecks[[.noncriticalCheckId]]$checkTitle
                    , "  \n"))
         cat(paste0("Description: "
@@ -128,8 +128,8 @@ cat(paste0("# ", datasetName, "  \n\n"))
         
         cat("\n")
     
-        cat(paste0("###  "
-                   ,.noncriticalCheckId
+        cat(paste0("###  Results of Non-Critical Check "
+                   ,as.numeric(gsub("\\D", "", .noncriticalCheckId))
                    ," - ", params$checkDataset$nonCriticalChecks[[datasetName]]$nPctList[[.noncriticalCheckId]]$checkTitle
                    , "  \n"))
         cat(paste0("Description: "
@@ -160,8 +160,8 @@ cat(paste0("# ", datasetName, "  \n\n"))
         
         cat("\n")
     
-        cat(paste0("###  "
-                   ,.noncriticalCheckId
+        cat(paste0("###  Results of Non-Critical Check "
+                   ,as.numeric(gsub("\\D", "", .noncriticalCheckId))
                    ," - ", params$checkDataset$nonCriticalChecks[[datasetName]]$summaryStats[[.noncriticalCheckId]]$checkTitle
                    , "  \n"))
         cat(paste0("Description: "

--- a/inst/rmarkdown/template.Rmd
+++ b/inst/rmarkdown/template.Rmd
@@ -35,7 +35,7 @@ cat(paste0("**Data pull date:** ",params$checkDataset$runnerSummary$pullDate,"  
 * cc6: Reasonable volume of disappearing rows
 * cc7: Item nonresponse for essential variables is not extreme
 * cc8: MoM (month over month) change in item nonresponse is reasonable for essential variables
-* cc9: Variables are of unexpected ‘type’
+* cc9: Variables are of expected ‘type’
 
 ```{r echo = FALSE, results = "asis"}
 summaryToPrint <- params$checkDataset$checkSummary$criticalCheckSummary

--- a/inst/rmarkdown/template.Rmd
+++ b/inst/rmarkdown/template.Rmd
@@ -95,7 +95,9 @@ cat(paste0("# ", datasetName, "  \n\n"))
     
         cat(paste0("###  Results of Non-Critical Check "
                    ,as.numeric(gsub("\\D", "", .noncriticalCheckId))
-                   ," - ", params$checkDataset$nonCriticalChecks[[datasetName]]$codebookChecks[[.noncriticalCheckId]]$checkTitle
+                   ," ("
+                   ,params$checkDataset$nonCriticalChecks[[datasetName]]$codebookChecks[[.noncriticalCheckId]]$checkId
+                   ,") - ", params$checkDataset$nonCriticalChecks[[datasetName]]$codebookChecks[[.noncriticalCheckId]]$checkTitle
                    , "  \n"))
         cat(paste0("Description: "
                    ,params$checkDataset$nonCriticalChecks[[datasetName]]$codebookChecks[[.noncriticalCheckId]]$checkDescription


### PR DESCRIPTION
Incorporate all appropriate changes from the first round of user testing of registrydqchecks

- Current   added variable for March 2024 datacut 'vhxtopical_super' should actually be   under CC3 - removed variables.    'Vhxtopical_super' was REMOVED in the March datacut and replaced with   'vhxtopical_highpotency.'
- Current removed variables for March 2024 datacut   'vhxtopical_highpotency' should actually be under CC2 - added variables.  'Vhxtopical_highpotency was ADDED in the   March datacut and replaces 'vhxtopical_super.'
- This section is actually showing variables removed from last   months.
- This section is actually showing variables added from last   months. Is CC2 and CC3 reversed?
- Request to deprecate use of Shiny dashboard and focus effort   on maintaining HTML report output.
- Is it possible to add what constitutes as a 'FAIL' proportion   in the description for the html report and anywhere in the CC5 section of the   shiny report please?  For instance, is   a failed proprtion 0.5?
- To Show # of records failed and proportioned failed under   checks
- Total observations' and 'Percentage failed' were shown as   'NA' in all nc1,3,4. We should be consisitent with whether to use 'percentage   failed' or 'proportion failed' accross the report. I vote for using   'percentage failed' in Shiny. Same suggestion for HTML.
- The label value of bmi_cat4 is not correct in codebook.   Updated in codebook.
- It appears that we had been missing value labels and some   variables were not in the labelled class for AD in March and April. It would   be good for the DQ code to be able to detect this as critical error
- This is probably just me but the data displayed here is not   intuitive - I am not able to understand why this failed.  I'm thinking the variable 'dataset' might   not be needed here since it is filtered to a specific dataset in the shiny   report and shown in the floating sections in the html report.
- it looks like AD codebook needs to update the delimiter after   value 3
- The display of $timestamp is not very clear to   understand.
- Please ignore if this observation is deemed extra picky.  Would it be possible to please swap nRows   and nMissing?  It might be easier to   assess the numbers with nMissing (the numerator) on the left and nRows (the   denominator) on the right.
- To add color indicators to display check pass (green) and   fail (red) result
- Suggest modifying 'Results of Check 1' to be 'Results of   Critical Check 1 (cc1)', same for other critical check display in Shiny.   Suggest modifying 'criticalCheck 1' to be 'Results of Critical Check 1   (cc1)', same for other critical check display in HTML.
- Is there an nc2?
- Suggest modifying 'propFailed' to be 'PercentFailed', and   presenting as percentage (ex. 100%, etc.)
- Did not find nc2. If it passed, should show as 'PASS'. Or, is   it not applicable for MS?
- It appears the numbering of Non-critical checks do not match   the list; Kaylee to work with Scott to resolve
- Suggest modifying 'Prop Missing' to be 'Current Month Prop   Missing' in Shiny. Suggest modifying 'propMissingComp' to be 'Previous Month   Prop Missing' in HTML.
- Show the name of the critical check when hovering over cc#;   for example, when hovering over cc1, "Zero duplicates" appear